### PR TITLE
イベント詳細ページ機能実装

### DIFF
--- a/app/action/Event/Info.php
+++ b/app/action/Event/Info.php
@@ -42,8 +42,7 @@
 
 class Yeahcheese_Action_EventInfo extends Yeahcheese_ActionClass
 {
-
-    public function perform()
+    public function prepare()
     {
         $eventdata = ($this->af->form_vars);
         $this->af->setApp('eventdata', $eventdata);
@@ -53,6 +52,13 @@ class Yeahcheese_Action_EventInfo extends Yeahcheese_ActionClass
             }
         }
         $this->af->setApp('event_photo', $eventphoto);
+        return null;
+    }
+
+
+
+    public function perform()
+    {
         return 'event_info';
     }
 }

--- a/app/action/Event/Info.php
+++ b/app/action/Event/Info.php
@@ -5,7 +5,7 @@
  */
  class Yeahcheese_Form_EventInfo extends Yeahcheese_ActionForm
  {
-     public $form = array(
+     public $form = [
        'event_id' => [
          'name'          => 'イベントID',
          'required'      => true,
@@ -37,7 +37,7 @@
          'type'          => VAR_TYPE_FILE,
          'file_size_max' => '5000KB',
          ],
-      );
+     ];
  }
 
 class Yeahcheese_Action_EventInfo extends Yeahcheese_ActionClass

--- a/app/action/Event/Info.php
+++ b/app/action/Event/Info.php
@@ -3,42 +3,42 @@
  *  Event/Info.php
  *  Action イベントページ表示
  */
- class Yeahcheese_Form_EventInfo extends Yeahcheese_ActionForm
- {
-     public $form = [
-       'event_id' => [
-         'name'          => 'イベントID',
-         'required'      => true,
-         'type'          => VAR_TYPE_STRING,
-         ],
-       'event_key' => [
-         'name'          => '認証キー',
-         'required'      => true,
-         'type'          => VAR_TYPE_STRING,
-         ],
-       'event_name' => [
-         'name'          => 'イベント名',
-         'required'      => true,
-         'type'          => VAR_TYPE_STRING,
-         ],
-       'event_start_day' => [
-         'name'          => '公開開始日',
-         'required'      => true,
-         'type'          => VAR_TYPE_DATETIME,
-         ],
-       'event_end_day' => [
-         'name'          => '公開終了日',
-         'required'      => true,
-         'type'          => VAR_TYPE_DATETIME,
-         ],
-       'event_photo' => [
-         'name'          => '写真',
-         'required'      => true,
-         'type'          => VAR_TYPE_FILE,
-         'file_size_max' => '5000KB',
-         ],
-     ];
- }
+class Yeahcheese_Form_EventInfo extends Yeahcheese_ActionForm
+{
+    public $form = [
+        'event_id' => [
+            'name'          => 'イベントID',
+            'required'      => true,
+            'type'          => VAR_TYPE_STRING,
+        ],
+        'event_key' => [
+            'name'          => '認証キー',
+            'required'      => true,
+            'type'          => VAR_TYPE_STRING,
+        ],
+        'event_name' => [
+            'name'          => 'イベント名',
+            'required'      => true,
+            'type'          => VAR_TYPE_STRING,
+        ],
+        'event_start_day' => [
+            'name'          => '公開開始日',
+            'required'      => true,
+            'type'          => VAR_TYPE_DATETIME,
+        ],
+        'event_end_day' => [
+            'name'          => '公開終了日',
+            'required'      => true,
+            'type'          => VAR_TYPE_DATETIME,
+        ],
+        'event_photo' => [
+            'name'          => '写真',
+            'required'      => true,
+            'type'          => VAR_TYPE_FILE,
+            'file_size_max' => '5000KB',
+        ],
+    ];
+}
 
 class Yeahcheese_Action_EventInfo extends Yeahcheese_ActionClass
 {
@@ -54,8 +54,6 @@ class Yeahcheese_Action_EventInfo extends Yeahcheese_ActionClass
         $this->af->setApp('event_photo', $eventphoto);
         return null;
     }
-
-
 
     public function perform()
     {

--- a/app/action/Event/Info.php
+++ b/app/action/Event/Info.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ *  Event/Info.php
+ *  Action イベントページ表示
+ */
+ class Yeahcheese_Form_EventInfo extends Yeahcheese_ActionForm
+ {
+     public $form = array(
+       'event_id' => [
+         'name'          => 'イベントID',
+         'required'      => true,
+         'type'          => VAR_TYPE_STRING,
+         ],
+       'event_key' => [
+         'name'          => '認証キー',
+         'required'      => true,
+         'type'          => VAR_TYPE_STRING,
+         ],
+       'event_name' => [
+         'name'          => 'イベント名',
+         'required'      => true,
+         'type'          => VAR_TYPE_STRING,
+         ],
+       'event_start_day' => [
+         'name'          => '公開開始日',
+         'required'      => true,
+         'type'          => VAR_TYPE_DATETIME,
+         ],
+       'event_end_day' => [
+         'name'          => '公開終了日',
+         'required'      => true,
+         'type'          => VAR_TYPE_DATETIME,
+         ],
+       'event_photo' => [
+         'name'          => '写真',
+         'required'      => true,
+         'type'          => VAR_TYPE_FILE,
+         'file_size_max' => '5000KB',
+         ],
+      );
+ }
+
+class Yeahcheese_Action_EventInfo extends Yeahcheese_ActionClass
+{
+
+    public function perform()
+    {
+        $eventdata = ($this->af->form_vars);
+        $this->af->setApp('eventdata', $eventdata);
+        foreach (glob('uploads/'.$eventdata['event_key'].'/*') as $file) {
+            if (is_file($file)) {
+                $eventphoto[] = $file;
+            }
+        }
+        $this->af->setApp('event_photo', $eventphoto);
+        return 'event_info';
+    }
+}

--- a/app/action/Event/Info.php
+++ b/app/action/Event/Info.php
@@ -31,12 +31,6 @@ class Yeahcheese_Form_EventInfo extends Yeahcheese_ActionForm
             'required'      => true,
             'type'          => VAR_TYPE_DATETIME,
         ],
-        'event_photo' => [
-            'name'          => '写真',
-            'required'      => true,
-            'type'          => VAR_TYPE_FILE,
-            'file_size_max' => '5000KB',
-        ],
     ];
 }
 

--- a/template/ja_JP/event/info.tpl
+++ b/template/ja_JP/event/info.tpl
@@ -1,0 +1,45 @@
+<h2>event_info<h2>
+    <form action="." method="post">
+    <table border="0">
+      <p>
+      <tr>
+        <td>イベントID</td>
+        <td>{$app.eventdata.event_id}</td>
+        <td><input type="hidden" name="event_id" value="{$eventdata.event_id}" readonly required></td>
+      </tr>
+      <tr>
+        <td>イベント名</td>
+        <td>{$app.eventdata.event_name}</td>
+        <td><input type="hidden" name="event_name" value="{$eventdata.event_name}" readonly required></td>
+      </tr>
+      <tr>
+        <td>イベント認証キー</td>
+        <td>{$app.eventdata.event_key}</td>
+        <td><input type="hidden" name="event_key" value="{$eventdata.event_key}" readonly required></td>
+      </tr>
+      <tr>
+        <td>イベント公開日</td>
+        <td>{$app.eventdata.event_start_day}</td>
+        <td><input type="hidden" name="event_start_day" value="{$eventdata.event_start_day}" readonly required></td>
+      </tr>
+      <tr>
+        <td>イベント終了日</td>
+        <td>{$app.eventdata.event_end_day}</td>
+        <td><input type="hidden" name="event_end_day" value="{$eventdata.event_end_day}" readonly required></td>
+      </tr>
+      <tr>
+        <td>イベント写真</td>
+        {foreach from=$app.event_photo item=photo_url}
+        <td><img src={$photo_url} width="128" height="128"></li></td>
+        <td><input type="hidden" name="event_photo_url[]" value="{$photo_url}" readonly required></td>
+        {/foreach}
+      </tr>
+      <tr>
+        <td><input type="submit" name="action_event_create" value="編集"></td>
+    </tr>
+    <tr>
+        <td><p><a href="/?action_event_list=true">イベント一覧</a></p></td>
+      </tr>
+    </table>
+    </p>
+    </form>

--- a/template/ja_JP/event/info.tpl
+++ b/template/ja_JP/event/info.tpl
@@ -1,45 +1,43 @@
 <h2>event_info<h2>
     <form action="." method="post">
     <table border="0">
-      <p>
-      <tr>
-        <td>イベントID</td>
-        <td>{$app.eventdata.event_id}</td>
-        <td><input type="hidden" name="event_id" value="{$eventdata.event_id}" readonly required></td>
-      </tr>
-      <tr>
-        <td>イベント名</td>
-        <td>{$app.eventdata.event_name}</td>
-        <td><input type="hidden" name="event_name" value="{$eventdata.event_name}" readonly required></td>
-      </tr>
-      <tr>
-        <td>イベント認証キー</td>
-        <td>{$app.eventdata.event_key}</td>
-        <td><input type="hidden" name="event_key" value="{$eventdata.event_key}" readonly required></td>
-      </tr>
-      <tr>
+        <tr>
+            <td>イベントID</td>
+            <td>{$app.eventdata.event_id}</td>
+            <td><input type="hidden" name="event_id" value="{$eventdata.event_id}" readonly required></td>
+        </tr>
+        <tr>
+            <td>イベント名</td>
+            <td>{$app.eventdata.event_name}</td>
+            <td><input type="hidden" name="event_name" value="{$eventdata.event_name}" readonly required></td>
+        </tr>
+        <tr>
+            <td>イベント認証キー</td>
+            <td>{$app.eventdata.event_key}</td>
+            <td><input type="hidden" name="event_key" value="{$eventdata.event_key}" readonly required></td>
+        </tr>
+        <tr>
         <td>イベント公開日</td>
-        <td>{$app.eventdata.event_start_day}</td>
-        <td><input type="hidden" name="event_start_day" value="{$eventdata.event_start_day}" readonly required></td>
-      </tr>
-      <tr>
+            <td>{$app.eventdata.event_start_day}</td>
+            <td><input type="hidden" name="event_start_day" value="{$eventdata.event_start_day}" readonly required></td>
+        </tr>
+        <tr>
         <td>イベント終了日</td>
-        <td>{$app.eventdata.event_end_day}</td>
-        <td><input type="hidden" name="event_end_day" value="{$eventdata.event_end_day}" readonly required></td>
-      </tr>
-      <tr>
+            <td>{$app.eventdata.event_end_day}</td>
+            <td><input type="hidden" name="event_end_day" value="{$eventdata.event_end_day}" readonly required></td>
+        </tr>
+        <tr>
         <td>イベント写真</td>
         {foreach from=$app.event_photo item=photo_url}
-        <td><img src={$photo_url} width="128" height="128"></li></td>
-        <td><input type="hidden" name="event_photo_url[]" value="{$photo_url}" readonly required></td>
+            <td><img src={$photo_url} width="128" height="128"></li></td>
+            <td><input type="hidden" name="event_photo_url[]" value="{$photo_url}" readonly required></td>
         {/foreach}
-      </tr>
-      <tr>
-        <td><input type="submit" name="action_event_create" value="編集"></td>
-    </tr>
-    <tr>
-        <td><p><a href="/?action_event_list=true">イベント一覧</a></p></td>
-      </tr>
+        </tr>
+        <tr>
+            <td><input type="submit" name="action_event_create" value="編集"></td>
+        </tr>
+        <tr>
+            <td><p><a href="/?action_event_list=true">イベント一覧</a></p></td>
+        </tr>
     </table>
-    </p>
-    </form>
+</form>


### PR DESCRIPTION
イベントデータ自体はイベント一覧から取得しています。(イベント一覧でDBから取得し、type=hiddenにして送信)
イベント詳細ページから新たに取得するデータはwww/uploads/EventKey/以下にある画像ファイルを読み込んで出力するだけとなっています。
このPRではイベント一覧機能は実装してません

//////////////イベント詳細画面//////////////

<img width="674" alt="2018-04-20 18 14 24" src="https://user-images.githubusercontent.com/7807989/39043874-83d301a0-44c9-11e8-877a-fd6a2ac65aef.png">


//////////////イベントイベント一覧////////////////

<img width="360" alt="2018-04-20 18 35 30" src="https://user-images.githubusercontent.com/7807989/39043952-ba5c99a2-44c9-11e8-82d5-f97aca03cfee.png">
